### PR TITLE
Specifying types declaration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,
+    "declarationDir": "./types",
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Currently, package consumer projects are unable to leverage the power of this strongly-typed SDK, because there wasn't any config specifying output types.

Changes:
In `tsconfig.json`, specified `declarationDir` as a dedicated directory to store type files generated